### PR TITLE
Protect from instantiations

### DIFF
--- a/DebugLog-Demo/src/com/mustafaferhan/debuglog/DebugLog.java
+++ b/DebugLog-Demo/src/com/mustafaferhan/debuglog/DebugLog.java
@@ -28,6 +28,9 @@ public class DebugLog{
 	static String className;
 	static String methodName;
 	
+    private DebugLog(){
+        /* Protect from instantiations */
+    }
 
 	public static boolean isDebuggable(){
 		return BuildConfig.DEBUG;


### PR DESCRIPTION
Isn't a good practice to create a protected constructor in classes that shouldn't be instantiated?
